### PR TITLE
Github action addition

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: btn
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pip install tox
+        tox

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: btn
 
 on:
@@ -35,6 +32,8 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      env:
+        APIKEY: ${{ secrets.APIKEY }}
       run: |
-        pip install tox
-        tox
+        pip install pytest
+        pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonrpc-requests

--- a/tests/test_btn.py
+++ b/tests/test_btn.py
@@ -1,6 +1,11 @@
-import pytest
 from btn.btn import btn
-from .config import APIKEY
+
+import pytest
+try:
+    from .config import APIKEY
+except ImportError:
+    from os import getenv
+    APIKEY = getenv('APIKEY')
 
 
 class TestBtn:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37
+envlist = py35, py36, py37, py38
 
 [testenv]
 deps =


### PR DESCRIPTION
Why do we need this change?
----
Update to add github actions to test across different versions
automatically

What effects does this change have?
----
* Adds a github action to run the tests
* Ensures we have a requirements.txt file
* Update the tests to try importing from the config file and fall back
  to ENV variable to support workflows with private
* Add python38 to the mix for tox